### PR TITLE
Replace () with {} in Stateless Component

### DIFF
--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -62,8 +62,20 @@
   "Stateless Component": {
     "prefix": "sl",
     "body": [
-      "const $1 = () => {",
+      "const $1 = () => (",
       "\t$2",
+      ");",
+      "",
+      "export default $1;"
+    ]
+  },
+  "Stateless Component Return": {
+    "prefix": "slr",
+    "body": [
+      "const $1 = () => {",
+      "\treturn (",
+      "\t\t$2",
+      "\t);",
       "};",
       "",
       "export default $1;"

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -62,9 +62,9 @@
   "Stateless Component": {
     "prefix": "sl",
     "body": [
-      "const $1 = () => (",
+      "const $1 = () => {",
       "\t$2",
-      ");",
+      "};",
       "",
       "export default $1;"
     ]


### PR DESCRIPTION
This will fix the linting error produced because of the incorrect syntax (statement expected).
Arrow function syntax: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions