### PR TITLE
[HOTFIX] Fix React Stateless Function syntax.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [2.0.6 - Fixed]
+- Fix React Stateless Function `rsf` syntax
+
 ## [2.0.5 - Added]
 - Add React Stateless Function `rsf`
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-native-react-redux",
   "displayName": "React-Native/React/Redux snippets for es6/es7",
   "description": "Code snippets for React-Native/React/Redux es6/es7 and flowtype/typescript, Storybook",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "galleryBanner": {
     "theme": "light",
     "color": "#FFFFFF"

--- a/snippets/snippets.json
+++ b/snippets/snippets.json
@@ -442,7 +442,7 @@
     "body": [
       "import React from 'react';",
       "",
-      "function ${TM_FILENAME_BASE}(props) => {",
+      "function ${TM_FILENAME_BASE}(props) {",
       "\treturn (",
       "\t\t<div>",
       "\t\t\t",


### PR DESCRIPTION
`rsf` code snippet is invalid due to arrow syntax.

* Removes extra `=>` from rsf snippet. My bad 😅 